### PR TITLE
배포 워크플로우에 Docker 빌드 추가

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -26,4 +26,5 @@ jobs:
                       set -e
                       cd ~/prod/llm-chat-client
                       git pull origin main
+                      make docker-build
                       make docker-run


### PR DESCRIPTION
- 배포 과정에서 Docker 이미지를 빌드하는 `make docker-build` 명령어를 추가하여 배포 프로세스를 개선함