### PR TITLE
키워드 제목 유효성 검사 개선

### DIFF
--- a/static/js/keyword_manager.js
+++ b/static/js/keyword_manager.js
@@ -43,9 +43,8 @@ export async function addKeyword(title) {
         return;
     }
     // title에 특수문자가 포함되어 있으면 추가 불가
-    if (title.match(/[^\w\s]/)) {
+    if (title.match(/[^\w\s가-힣]/)) {
         alert('키워드에 특수문자를 포함할 수 없습니다.');
-        // 입력창 초기화
         keywordInputElement.value = '';
         return;
     }


### PR DESCRIPTION
- `keyword_manager.js` 파일에서 키워드 제목의 유효성 검사를 수정하여 한글을 포함한 특수문자만 허용하도록 변경함