### PR TITLE
토큰 갱신 및 인증 요청에 credentials 옵션 추가

### DIFF
--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -80,6 +80,7 @@ async function refreshTokenAndRetry(originalUrl, originalOptions) {
         // 중요: 토큰 갱신 요청은 fetchWithAuth를 사용하지 않음 (무한 루프 방지)
         const refreshResponse = await fetch(`${API_URL}/user/v1/token/refresh`, {
             method: 'POST',
+            credentials: 'include',
         });
 
         if (refreshResponse.ok) {
@@ -128,6 +129,7 @@ async function fetchWithAuth(url, options = {}) {
         ...options,
         headers: mergedHeaders,
         body: body,
+        credentials: 'include',
     };
 
     try {


### PR DESCRIPTION
- `auth.js` 파일에서 refreshTokenAndRetry 및 fetchWithAuth 함수에 credentials: 'include' 옵션을 추가하여 쿠키를 포함한 요청을 가능하게 함